### PR TITLE
feat: add link card for markdown

### DIFF
--- a/.contents/card-links.json
+++ b/.contents/card-links.json
@@ -1,0 +1,12 @@
+{
+  "https://google.com": {
+    "title": "Google",
+    "description": "世界中のあらゆる情報を検索するためのツールを提供しています。さまざまな検索機能を活用して、お探しの情報を見つけてください。",
+    "image": ""
+  },
+  "https://oriverk.dev/blog/20240300-gfm-alerts/": {
+    "title": "GFM Alerts記法のスニペットを設定する | oriverk.dev",
+    "description": "",
+    "image": "https://oriverk.dev/api/og/blog/20240300-gfm-alerts.png"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
-.contents
+.contents/posts.json
+.contents/contributions.json
+.contents/repository.json
+.contents/feed.json
 src/content/static/cv.md

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,4 @@
-import mdx from "@astrojs/mdx";
+import mdx, { type MdxOptions } from "@astrojs/mdx";
 import svelte from "@astrojs/svelte";
 import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
 import expressiveCode from "astro-expressive-code";
@@ -13,7 +13,6 @@ import {
   remarkFencedCodeBlock,
 } from "./src/utils/markdown";
 
-// https://astro.build/config
 export default defineConfig({
   site: "https://oriverk.dev",
   publicDir: "./public",
@@ -42,7 +41,11 @@ export default defineConfig({
       remarkFencedCodeBlock,
       remarkGithubAlerts,
     ],
-    rehypePlugins: [rehypeAnchor, rehypeFigure, rehypeKatex],
+    rehypePlugins: [
+      rehypeAnchor,
+      rehypeFigure,
+      rehypeKatex
+    ],
     gfm: true,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.0",
         "date-fns": "^3.6.0",
         "dotenv": "^16.4.5",
+        "fetch-site-metadata": "^0.2.0",
         "gray-matter": "^4.0.3",
         "hast": "^1.0.0",
         "mdast": "^3.0.0",
@@ -8386,6 +8387,19 @@
         "node-fetch": "~2.6.0"
       }
     },
+    "node_modules/fetch-site-metadata": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-site-metadata/-/fetch-site-metadata-0.2.0.tgz",
+      "integrity": "sha512-W22/mYb9/PIX/gHz52qDf2ZjeoDi+Lf/oM/n4vdYW/82UUrKLJPJD755Ak4asRyNLdGTwTXgBZ+3WinRVh7k7A==",
+      "dependencies": {
+        "entities": "^4.5.0",
+        "html-rewriter-wasm": "^0.4.1",
+        "probe-image-size": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -9366,6 +9380,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
+    "node_modules/html-rewriter-wasm": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+      "integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q=="
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -9401,6 +9420,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -10389,8 +10419,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -13959,6 +13988,30 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "optional": true
     },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/nlcst-to-string": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.1.tgz",
@@ -15139,6 +15192,16 @@
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
       }
     },
     "node_modules/prompts": {
@@ -16778,6 +16841,11 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/sass": {
       "version": "1.70.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
@@ -17266,6 +17334,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/streamx": {
       "version": "2.16.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
+    "fetch-site-metadata": "^0.2.0",
     "gray-matter": "^4.0.3",
     "hast": "^1.0.0",
     "mdast": "^3.0.0",

--- a/src/components/AstroLink.astro
+++ b/src/components/AstroLink.astro
@@ -1,0 +1,18 @@
+---
+import Linkcard from "@/components/LinkCard.astro";
+import type { HTMLAttributes } from "astro/types";
+
+interface Props extends HTMLAttributes<"a"> {}
+
+const {href, class: className, ...restProps} = Astro.props;
+---
+
+{
+  className?.includes("link-card") ? (
+    <Linkcard href={href?.toString() || ""} />
+  ) : (
+    <a {href} {...restProps}>
+      <slot />
+    </a>
+  )
+}

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -1,0 +1,101 @@
+---
+import { getFaviconSrcFromOrigin } from '@/utils/feed';
+import { getSiteMetadata } from '@/utils/getSiteMetadata';
+import Card from './ui/Card.svelte';
+
+interface Props {
+  href: string;
+}
+
+const { href } = Astro.props;
+
+const {title, description, image} = await getSiteMetadata(href);
+const { origin, hostname } = new URL(href)
+const favicon = getFaviconSrcFromOrigin(origin)
+---
+
+<div>
+  <a {href} class="card" target="_blank" rel="noopener noreferrer">
+    <Card>
+      <div class="content">
+        <div class="left">
+          <h3 class="title">{title}</h3>
+          <p class="description">{description}</p>
+          <div class="info">
+            <img
+              src={favicon}
+              width="14"
+              height="14"
+              alt={hostname}
+            />
+            <span>{hostname}</span>
+          </div>
+        </div>
+        {image && (
+          <div class="ogimage">
+            <img src={image} alt={title} width={400} class="image" />
+          </div>
+        )}
+      </div>
+    </Card>
+  </a>
+</div>
+
+<style>
+  .card {
+    width: 100%;
+    display: inline-block;
+    text-decoration: none;
+  }
+
+  .content {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .left {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .title {
+    &::before {
+      content: none;
+    }
+
+    font-weight: bold;
+  }
+
+  .title {
+    margin: 0;
+    font-size: 1.2rem;
+  }
+
+  .description {
+    flex: 1;
+    justify-items: center;
+    font-size: 0.9rem;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .info {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+
+    & > img {
+      width: revert;
+    }
+
+    & > span {
+      color: rgb(var(--color-lightgray));
+    }
+  }
+
+  .ogimage {
+    width: 25%;
+  }
+</style>

--- a/src/content/blog/anchor-test.mdx
+++ b/src/content/blog/anchor-test.mdx
@@ -1,0 +1,19 @@
+---
+create: '2024-04-06'
+update: '2024-04-06'
+title: 'add link card'
+tags: []
+published: true
+---
+
+## heading
+
+### barelink
+
+https://google.com
+
+https://oriverk.dev/blog/20240300-gfm-alerts/
+
+### list anchors
+
+- [https://google.com](https://google.com)

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,6 +4,7 @@ import ContentWrapper from "@/components/ui/ContentWrapper.svelte";
 import Markdown from "@/components/ui/Markdown.svelte";
 import Layout from "@/layouts/Layout.astro";
 import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import AstroLink from "@/components/AstroLink.astro"
 
 export const getStaticPaths = (async () => {
   const posts = await getCollection("static");
@@ -22,6 +23,10 @@ const { render, data } = post;
 const { title, create, description, update, noindex } = data;
 
 const { Content } = await render();
+
+export const components = {
+  a: AstroLink,
+}
 ---
 
 <Layout {title} {description} {noindex}>
@@ -36,7 +41,7 @@ const { Content } = await render();
           </div>
         </div>
         <Markdown>
-          <Content />
+          <Content {components} />
         </Markdown>
         </div>
     </ContentWrapper>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+import AstroLink from "@/components/AstroLink.astro";
 import PostTag from "@/components/PostTag.svelte";
 import ContentWrapper from "@/components/ui/ContentWrapper.svelte";
 import Details from "@/components/ui/Details.svelte";
@@ -36,6 +37,10 @@ const isoDate = lastModified.toISOString();
 const { Content, headings } = await render();
 const toc = getTocHierarchy(headings);
 const ogImage = urlJoin(Astro.url.origin, "/api/og/blog", `${slug}.png`);
+
+export const components = {
+  a: AstroLink
+}
 ---
 
 <Layout {title} {description} {noindex} image={ogImage}>
@@ -62,7 +67,7 @@ const ogImage = urlJoin(Astro.url.origin, "/api/og/blog", `${slug}.png`);
           </Details>
         </nav>
         <Markdown>
-          <Content />
+          <Content {components} />
         </Markdown>
         </div>
     </ContentWrapper>

--- a/src/utils/getSiteMetadata.ts
+++ b/src/utils/getSiteMetadata.ts
@@ -1,0 +1,50 @@
+import path from "node:path"
+import fs from "fs-extra"
+import fetchSiteMetadata from "fetch-site-metadata";
+
+type linksJson = Record<string, {
+  title: string;
+  description: string;
+  image: string;
+}>
+
+export async function getSiteMetadata(url: string) {
+  const linksPath = path.join(process.cwd(), ".contents/card-links.json");  
+  await fs.ensureFile(linksPath)
+  const linksJson: linksJson = await fs.readJson(linksPath) || {};
+  let title = "";
+  let description = "";
+  let image = "";
+
+  if(linksJson[url]){
+    title = linksJson[url].title;
+    description = linksJson[url].description
+    image = linksJson[url].image
+  } else {
+    const result = await fetchSiteMetadata(url);
+    title = result.title ?? "";
+    description = result.description ?? "";
+    image = result.image?.src ?? ""
+
+    if(import.meta.env.PROD){
+      await fs.writeJson(linksPath, {
+        ...linksJson,
+        [url]: {
+          title,
+          description,
+          image
+        }
+      }, 
+      {
+        spaces: 2,
+      })
+    }
+  }
+
+  return {
+    src: url,
+    title,
+    description,
+    image
+  }
+}

--- a/src/utils/markdown/isHastNode.ts
+++ b/src/utils/markdown/isHastNode.ts
@@ -31,3 +31,7 @@ interface Anchor extends Element {
 export function isAnchor(node: unknown): node is Anchor {
   return isElement(node) && node.tagName === "a";
 }
+
+export function isBareLink(node: unknown) {
+  return isAnchor(node) && isLiteral(node.children[0]) && node.children[0].value === node.properties.href
+}

--- a/src/utils/markdown/rehypeAnchor.ts
+++ b/src/utils/markdown/rehypeAnchor.ts
@@ -1,17 +1,24 @@
 import type { Plugin } from "unified";
+import type { Root } from "hast";
 import type { Parent } from "unist";
 import { visit } from "unist-util-visit";
-import { isAnchor, isParent } from "./isHastNode";
+import { isAnchor, isParent, isElement, isBareLink } from "./isHastNode";
 
-export const rehypeAnchor: Plugin = () => {
+// biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
+export const rehypeAnchor: Plugin<void[], Root> = () => {
   return (tree) => {
     visit(tree, isAnchor, (node, _index, parent: Parent | undefined) => {
       if (!isParent(parent)) return;
-      const { href } = node.properties as { href: string };
-      if (!href.startsWith("http")) return;
+      const { properties } = node;
+      const { href } = properties as { href: string };
 
-      node.properties.target = "_blank";
-      node.properties.rel = "noopener noreferrer";
+      if (!href.startsWith("http")) return;
+      properties.target = "_blank";
+      properties.rel = "noopener noreferrer";
+      
+      if(isBareLink(node) && isElement(parent) && parent.tagName === "p"){
+        properties.class = ["link-card"]
+      }
     });
   };
 };

--- a/src/utils/markdown/rehypeFigure.ts
+++ b/src/utils/markdown/rehypeFigure.ts
@@ -1,20 +1,22 @@
 import type { Plugin } from "unified";
+import type {Root} from "hast"
 import { is } from "unist-util-is";
 import { visit } from "unist-util-visit";
 
-export const rehypeFigure: Plugin = () => {
+// biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
+export const rehypeFigure: Plugin<void[], Root> = () => {
   return (tree) => {
     visit(tree, (node) => {
       if (is(node, { tagName: "p" })) {
-        // @ts-ignore
-        const children = node.children;
+        const { children } = node;
         if (children.length === 1 && is(children[0], { tagName: "img" })) {
           node.tagName = "figure";
 
           children[0].properties.loading = "lazy";
           children[0].properties.decoding = "async";
+          const caption = children[0].properties.title
 
-          if (children[0].properties.title) {
+          if (caption && typeof caption === "string") {
             children.push({
               type: "element",
               tagName: "figcaption",
@@ -22,7 +24,7 @@ export const rehypeFigure: Plugin = () => {
               children: [
                 {
                   type: "text",
-                  value: children[0].properties.title,
+                  value: caption,
                 },
               ],
             });

--- a/src/utils/markdown/remarkFencedCodeBlock.ts
+++ b/src/utils/markdown/remarkFencedCodeBlock.ts
@@ -1,9 +1,11 @@
+import type { Root } from "mdast";
 import type { Plugin } from "unified";
 import type { Parent } from "unist";
 import { visit } from "unist-util-visit";
 import { isCode, isParent } from "./isMdastNode";
 
-export const remarkFencedCodeBlock: Plugin = () => {
+// biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
+export const remarkFencedCodeBlock: Plugin<void[], Root> = () => {
   return (tree) => {
     visit(tree, isCode, (node, _index, parent: Parent | undefined) => {
       if (!isParent(parent)) return;


### PR DESCRIPTION
# related issues

Fixes #10

## Changes proposed in this pull request

- display og image card link in markdown pages

## the background (as memo)

- create rehype plugin to detect bare links and to add className to these
- use [fabon-f/fetch-site-metadata: High-performance metadata scraper](https://github.com/fabon-f/fetch-site-metadata)

